### PR TITLE
Makes possible to provide a string resource for the sender id

### DIFF
--- a/android-easy-gcm/android-easy-gcm/src/main/java/com/joxad/easygcm/EasyGcm.java
+++ b/android-easy-gcm/android-easy-gcm/src/main/java/com/joxad/easygcm/EasyGcm.java
@@ -3,6 +3,8 @@ package com.joxad.easygcm;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.joxad.easygcm.error.PlayServiceNotAvailableException;
@@ -100,6 +102,7 @@ public class EasyGcm {
 
         private Context mContext;
         private String mSenderId;
+        private Integer mSenderIdRes = null;
         private boolean logEnable = false;
 
         /**
@@ -108,7 +111,7 @@ public class EasyGcm {
          * @param context the application context
          * @return the {@link com.} object.EasyGcm
          */
-        public Builder context(final Context context) {
+        public Builder context(@NonNull final Context context) {
             mContext = context;
             return this;
         }
@@ -119,8 +122,19 @@ public class EasyGcm {
          * @param senderId the identification of the GCM
          * @return the {@link com.} object.EasyGcm
          */
-        public Builder senderId(final String senderId) {
+        public Builder senderId(@NonNull final String senderId) {
             this.mSenderId = senderId;
+            return this;
+        }
+
+        /**
+         * Set the Context used to instantiate the EasyGcm
+         *
+         * @param senderIdRes the resource identification of the GCM
+         * @return the {@link com.} object.EasyGcm
+         */
+        public Builder senderId(@StringRes final int senderIdRes) {
+            this.mSenderIdRes = senderIdRes;
             return this;
         }
 
@@ -145,8 +159,10 @@ public class EasyGcm {
             if (mContext == null) {
                 throw new RuntimeException("Context not set, please set context");
             }
-            if (mSenderId == null) {
+            if (mSenderId == null && mSenderIdRes == null) {
                 throw new RuntimeException("Sender Id not set, please set the id");
+            } else {
+                mSenderId = (mSenderId != null) ? mSenderId : mContext.getString(mSenderIdRes);
             }
 
 

--- a/android-easy-gcm/sample/src/main/java/com/joxad/easygcmsample/MainActivity.java
+++ b/android-easy-gcm/sample/src/main/java/com/joxad/easygcmsample/MainActivity.java
@@ -19,6 +19,8 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         try {
             new EasyGcm.Builder().context(this).senderId(getString(R.string.app_senderid)).enableLog(true).build();
+            // Could use
+            // new EasyGcm.Builder().context(this).senderId(R.string.app_senderid).enableLog(true).build();
         } catch (PlayServiceNotAvailableException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Add a method `senderId(@StringRes final int)` to make possible to the user to give a string resource instead of getting the string by himself in the setup.
